### PR TITLE
Move UID/GID stuff to entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,13 @@ RUN apt install -y bsdmainutils
 RUN pip install frida-tools
 RUN apt install -y openssh-server
 RUN mkdir -p /run/sshd
-RUN  echo 'nohup bash -c "/usr/sbin/sshd -p 24889 -D" 2>/dev/null & sleep 0.1 && sed -i "/nohup bash -c/d" /root/.bashrc' >> /root/.bashrc
 RUN mkdir -p /root/.ssh
+RUN printf 'export SHELL="/bin/bash"\nexport TERM="xterm-256color"\n' > /root/.bashrc
+RUN cat /etc/skel/.bashrc >> /root/.bashrc
 RUN echo 'alias pwninit="pwninit --template-path /tools/pwninitTemplate.py"' >> /root/.bashrc
 COPY pwninitTemplate.py /tools/pwninitTemplate.py
 COPY id_rsa.pub /root/.ssh/authorized_keys
+COPY entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+RUN adduser ctf
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,8 @@ cp ~/.ssh/id_rsa.pub ./id_rsa.pub
 echo "RUN groupadd --gid $(id | cut -d "(" -f2 | cut -d "=" -f2) $(whoami) && useradd --uid $(id | cut -d "(" -f1 | cut -d "=" -f2) --gid $(id | cut -d "(" -f2 | cut -d "=" -f2) -m $(whoami)" >> Dockerfile
 echo "RUN echo 'nohup bash -c \"while true; do chown -R $(whoami):$(whoami) /mnt/ && sleep 0.1; done\" 2>/dev/null &' >> /root/.bashrc" >> Dockerfile
 docker build -t ctf .
-sed -i "/RUN groupadd/d" Dockerfile
-sed -i "/RUN echo 'nohup/d" Dockerfile
 rm ./id_rsa.pub
 sed -i '/alias alsoctf/d' ~/.bashrc
 sed -i '/alias ctfhere/d' ~/.bashrc
-echo "alias ctfhere=\"pwd | xargs printf -- 'docker run -p24889:24889 -it --name ctf --rm -v %s:/mnt ctf:latest /bin/bash' | xargs xargs -o\"" >> ~/.bashrc
+echo "alias ctfhere=\"pwd | xargs printf -- 'docker run -p24889:24889 -it --name ctf -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) --rm -v %s:/mnt ctf:latest /bin/bash' | xargs xargs -o\"" >> ~/.bashrc
 echo "alias alsoctf=\"docker exec -it ctf /bin/bash\"" >> ~/.bashrc

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 cp ~/.ssh/id_rsa.pub ./id_rsa.pub
-echo "RUN groupadd --gid $(id | cut -d "(" -f2 | cut -d "=" -f2) $(whoami) && useradd --uid $(id | cut -d "(" -f1 | cut -d "=" -f2) --gid $(id | cut -d "(" -f2 | cut -d "=" -f2) -m $(whoami)" >> Dockerfile
-echo "RUN echo 'nohup bash -c \"while true; do chown -R $(whoami):$(whoami) /mnt/ && sleep 0.1; done\" 2>/dev/null &' >> /root/.bashrc" >> Dockerfile
 docker build -t ctf .
 rm ./id_rsa.pub
 sed -i '/alias alsoctf/d' ~/.bashrc
 sed -i '/alias ctfhere/d' ~/.bashrc
-echo "alias ctfhere=\"pwd | xargs printf -- 'docker run -p24889:24889 -it --name ctf -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) --rm -v %s:/mnt ctf:latest /bin/bash' | xargs xargs -o\"" >> ~/.bashrc
+echo "alias ctfhere=\"echo \\\"\$(id -u) \$(id -g) \$(pwd)\\\" | xargs printf -- 'docker run -p24889:24889 -it --name ctf -e HOST_UID=%s -e HOST_GID=%s --rm -v %s:/mnt ctf:latest /bin/bash' | xargs xargs -o\"" > rc
 echo "alias alsoctf=\"docker exec -it ctf /bin/bash\"" >> ~/.bashrc
 source ~/.bashrc

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,6 @@ docker build -t ctf .
 rm ./id_rsa.pub
 sed -i '/alias alsoctf/d' ~/.bashrc
 sed -i '/alias ctfhere/d' ~/.bashrc
-echo "alias ctfhere=\"echo \\\"\$(id -u) \$(id -g) \$(pwd)\\\" | xargs printf -- 'docker run -p24889:24889 -it --name ctf -e HOST_UID=%s -e HOST_GID=%s --rm -v %s:/mnt ctf:latest /bin/bash' | xargs xargs -o\"" > rc
+echo "alias ctfhere=\"echo \\\"\$(id -u) \$(id -g) \$(pwd)\\\" | xargs printf -- 'docker run -p24889:24889 -it --name ctf -e HOST_UID=%s -e HOST_GID=%s --rm -v %s:/mnt ctf:latest /bin/bash' | xargs xargs -o\"" >> ~/.bashrc
 echo "alias alsoctf=\"docker exec -it ctf /bin/bash\"" >> ~/.bashrc
 source ~/.bashrc

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 nohup bash -c "/usr/sbin/sshd -p 24889 -D" 2>/dev/null &
 nohup bash -c "while true; do chown -R $HOST_UID:$HOST_GID /mnt/; done" 2>/dev/null &
 
-groupmod --gid "$HOST_GID" ctf
-usermod --uid "$HOST_UID" ctf
+groupmod --gid "$HOST_GID" ctf 2>/dev/null
+usermod --uid "$HOST_UID" ctf 2>/dev/null
 
 if [ $# = 0 ]; then
     /bin/bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+nohup bash -c "/usr/sbin/sshd -p 24889 -D" 2>/dev/null &
+nohup bash -c "while true; do chown -R $HOST_UID:$HOST_GID /mnt/; done" 2>/dev/null &
+
+groupmod --gid "$HOST_GID" ctf
+usermod --uid "$HOST_UID" ctf
+
+if [ $# = 0 ]; then
+    /bin/bash
+else
+    exec "$@"
+fi


### PR DESCRIPTION
Bonne soiréee

I moved the fix for the file permissions to a entrypoint.sh script. This should be easier to maintain and containers can be run independent of where they were built, so the images could theoretically be pushed to an image repo (need to do something about the public ssh key though).

Cheers!